### PR TITLE
Fix #15 - Text sizing issue

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -21,13 +21,13 @@ function Graph(elements) {
   //  sort the elements so nodes are added before edges
   if (elements instanceof Array) {
     elements.sort((a,b) => {
-      return a.to ? 1: -1 
+      return a.to ? 1: -1
     }).forEach(el => this.add(el))
   }
 }
 
 
-/**  
+/**
  * Use Array as the prototype
  */
 Graph.prototype = Object.create(Array.prototype)
@@ -53,13 +53,13 @@ Graph.prototype.add = function (element) {
       return false
     }
 
-    //  Edges can connect independent or conjoined reasons. 
+    //  Edges can connect independent or conjoined reasons.
     //  If A B & C both already support D
     //  and a new edge is added from A to B or vice versa
     //  then the relationships should be merged [A,B] -> D
-    //  and C -> D kept unchanged      
+    //  and C -> D kept unchanged
     let commonChildren = Utils.intersection(
-      Utils.flatten(element.from.map(e => this.children(e))), 
+      Utils.flatten(element.from.map(e => this.children(e))),
       this.children(element.to)
     ).map(el => el.id)
 
@@ -81,7 +81,7 @@ Graph.prototype.add = function (element) {
         }
       })
     } else {
-      this.push(element)  
+      this.push(element)
     }
   }
 }
@@ -122,9 +122,9 @@ Graph.prototype.add = function (element) {
 
       //  also remove node from any complex relations
       edgesFrom.filter(e => e.from instanceof Array).map((e) => {
-        if (e.from.indexOf(el) > -1) 
+        if (e.from.indexOf(el) > -1)
           e.from.splice(e.from.indexOf(el), 1)
-        if (e.from.length === 1) 
+        if (e.from.length === 1)
           e.from = e.from[0]
       })
 
@@ -135,7 +135,7 @@ Graph.prototype.add = function (element) {
       })
     } else {
       this.splice(i, 1)
-    }  
+    }
   }
 
   //  permit chaining during tests
@@ -162,6 +162,18 @@ Graph.prototype.add = function (element) {
 
   //  permit chaining during tests
   return el
+}
+
+ Graph.prototype.undoFocus = function () {
+  const last = this.pop();
+  this.unshift(last);
+
+  this.forEach(function (e) {
+    e.focused = (e === last) ? true : false
+  })
+
+  //  permit chaining during tests
+  return last
 }
 
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -282,8 +282,13 @@ function addEventListeners (mapper) {
       //  Focus on `Tab`
       if (!isMetaKey(event) && Keycode.isEventKey(event, 'tab')) {
         event.preventDefault()
-        selected = mapper.graph[0]
-        mapper.graph.focus(selected)
+        if (event.shiftKey) {
+          mapper.graph.undoFocus()
+        } else {
+          selected = mapper.graph[0]
+          mapper.graph.focus(selected)
+        }
+        console.log(mapper.graph.map(g => g.id))
         mapper.dirty = true
       }
 

--- a/lib/view.js
+++ b/lib/view.js
@@ -145,6 +145,8 @@ function clear (mapper) {
  * Private: Draws a node on the canvas
  */
 function draw_node (node, {context, offset}) {
+  // Set font size before calculating text widths
+  context.font = fontSize + 'px sans-serif'
 
   //  word wrap the text
   const text = wordWrap(node.text, context)
@@ -169,7 +171,6 @@ function draw_node (node, {context, offset}) {
 
   //  set text box styles
   context.fillStyle = 'rgba('+rgb+',0.8)'
-  context.font = fontSize + 'px sans-serif'
   context.textAlign = 'center'
 
   const lineHeight = fontSize * 1.25;

--- a/reasons.js
+++ b/reasons.js
@@ -1259,6 +1259,8 @@ function clear (mapper) {
  * Private: Draws a node on the canvas
  */
 function draw_node (node, {context, offset}) {
+  // Set font size before calculating text widths
+  context.font = fontSize + 'px sans-serif'
 
   //  word wrap the text
   const text = wordWrap(node.text, context)
@@ -1283,7 +1285,6 @@ function draw_node (node, {context, offset}) {
 
   //  set text box styles
   context.fillStyle = 'rgba('+rgb+',0.8)'
-  context.font = fontSize + 'px sans-serif'
   context.textAlign = 'center'
 
   const lineHeight = fontSize * 1.25;

--- a/reasons.js
+++ b/reasons.js
@@ -232,13 +232,13 @@ function Graph(elements) {
   //  sort the elements so nodes are added before edges
   if (elements instanceof Array) {
     elements.sort((a,b) => {
-      return a.to ? 1: -1 
+      return a.to ? 1: -1
     }).forEach(el => this.add(el))
   }
 }
 
 
-/**  
+/**
  * Use Array as the prototype
  */
 Graph.prototype = Object.create(Array.prototype)
@@ -264,13 +264,13 @@ Graph.prototype.add = function (element) {
       return false
     }
 
-    //  Edges can connect independent or conjoined reasons. 
+    //  Edges can connect independent or conjoined reasons.
     //  If A B & C both already support D
     //  and a new edge is added from A to B or vice versa
     //  then the relationships should be merged [A,B] -> D
-    //  and C -> D kept unchanged      
+    //  and C -> D kept unchanged
     let commonChildren = Utils.intersection(
-      Utils.flatten(element.from.map(e => this.children(e))), 
+      Utils.flatten(element.from.map(e => this.children(e))),
       this.children(element.to)
     ).map(el => el.id)
 
@@ -292,7 +292,7 @@ Graph.prototype.add = function (element) {
         }
       })
     } else {
-      this.push(element)  
+      this.push(element)
     }
   }
 }
@@ -333,9 +333,9 @@ Graph.prototype.add = function (element) {
 
       //  also remove node from any complex relations
       edgesFrom.filter(e => e.from instanceof Array).map((e) => {
-        if (e.from.indexOf(el) > -1) 
+        if (e.from.indexOf(el) > -1)
           e.from.splice(e.from.indexOf(el), 1)
-        if (e.from.length === 1) 
+        if (e.from.length === 1)
           e.from = e.from[0]
       })
 
@@ -346,7 +346,7 @@ Graph.prototype.add = function (element) {
       })
     } else {
       this.splice(i, 1)
-    }  
+    }
   }
 
   //  permit chaining during tests
@@ -373,6 +373,18 @@ Graph.prototype.add = function (element) {
 
   //  permit chaining during tests
   return el
+}
+
+ Graph.prototype.undoFocus = function () {
+  const last = this.pop();
+  this.unshift(last);
+
+  this.forEach(function (e) {
+    e.focused = (e === last) ? true : false
+  })
+
+  //  permit chaining during tests
+  return last
 }
 
 
@@ -859,8 +871,13 @@ function addEventListeners (mapper) {
       //  Focus on `Tab`
       if (!isMetaKey(event) && Keycode.isEventKey(event, 'tab')) {
         event.preventDefault()
-        selected = mapper.graph[0]
-        mapper.graph.focus(selected)
+        if (event.shiftKey) {
+          mapper.graph.undoFocus()
+        } else {
+          selected = mapper.graph[0]
+          mapper.graph.focus(selected)
+        }
+        console.log(mapper.graph.map(g => g.id))
         mapper.dirty = true
       }
 


### PR DESCRIPTION
OK ... so, despite the simple fix, this was quite the ride to track down! 

When an item was a Node, that was getting rendered after an edge, the edge had set the font size to 14px, which was then used to calculate the widths, but then the font size was changed before actually rendering the font, so it rendered too big.

To help track this down, I implemented shift+tab to go backward through the list, and thought it might be helpful for you too.