### PR TITLE
When dragging, remember click offset, so drag doesn't jump

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -21,13 +21,13 @@ function Graph(elements) {
   //  sort the elements so nodes are added before edges
   if (elements instanceof Array) {
     elements.sort((a,b) => {
-      return a.to ? 1: -1 
+      return a.to ? 1: -1
     }).forEach(el => this.add(el))
   }
 }
 
 
-/**  
+/**
  * Use Array as the prototype
  */
 Graph.prototype = Object.create(Array.prototype)
@@ -53,13 +53,13 @@ Graph.prototype.add = function (element) {
       return false
     }
 
-    //  Edges can connect independent or conjoined reasons. 
+    //  Edges can connect independent or conjoined reasons.
     //  If A B & C both already support D
     //  and a new edge is added from A to B or vice versa
     //  then the relationships should be merged [A,B] -> D
-    //  and C -> D kept unchanged      
+    //  and C -> D kept unchanged
     let commonChildren = Utils.intersection(
-      Utils.flatten(element.from.map(e => this.children(e))), 
+      Utils.flatten(element.from.map(e => this.children(e))),
       this.children(element.to)
     ).map(el => el.id)
 
@@ -81,7 +81,7 @@ Graph.prototype.add = function (element) {
         }
       })
     } else {
-      this.push(element)  
+      this.push(element)
     }
   }
 }
@@ -122,9 +122,9 @@ Graph.prototype.add = function (element) {
 
       //  also remove node from any complex relations
       edgesFrom.filter(e => e.from instanceof Array).map((e) => {
-        if (e.from.indexOf(el) > -1) 
+        if (e.from.indexOf(el) > -1)
           e.from.splice(e.from.indexOf(el), 1)
-        if (e.from.length === 1) 
+        if (e.from.length === 1)
           e.from = e.from[0]
       })
 
@@ -135,7 +135,7 @@ Graph.prototype.add = function (element) {
       })
     } else {
       this.splice(i, 1)
-    }  
+    }
   }
 
   //  permit chaining during tests
@@ -162,6 +162,18 @@ Graph.prototype.add = function (element) {
 
   //  permit chaining during tests
   return el
+}
+
+ Graph.prototype.undoFocus = function () {
+  const last = this.pop();
+  this.unshift(last);
+
+  this.forEach(function (e) {
+    e.focused = (e === last) ? true : false
+  })
+
+  //  permit chaining during tests
+  return last
 }
 
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -78,6 +78,7 @@ function addEventListeners (mapper) {
   let selected = null
   let dragging = null
   let clickPos = null
+  let clickOffset = null
   let metaKeyPressed = false
 
   const localPosition = (event) => {
@@ -187,19 +188,23 @@ function addEventListeners (mapper) {
   const dragStart = (event) => {
 
     const {position, collision} = detect(event)
+    if (dragging) { return }
 
     if (collision) {
       selected = collision
       mapper.graph.focus(selected)
       mapper.dirty = true
       clickPos = position
+      clickOffset = {
+        x: (selected.x1 + (selected.width / 2)) - position.x,
+        y: (selected.y1 + (selected.height /2)) - position.y
+      }
       dragging = selected
     }
 
     redraw(mapper)
   }
   mapper.DOM.addEventListener('mousedown', dragStart)
-  // mapper.DOM.addEventListener('touchstart', dragStart)
 
   //  Move a selected element on drag
   //  Highlight a hovered element
@@ -220,7 +225,12 @@ function addEventListeners (mapper) {
 
     //  Specify a node as the drag target when clicked
     if (dragging) {
-      dragging.move(localPosition(event))
+      const localPos = localPosition(event)
+      console.log('drag', localPos, clickOffset)
+      dragging.move({
+        x: localPos.x + clickOffset.x,
+        y: localPos.y + clickOffset.y
+      })
       mapper.dirty = true
     }
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -282,8 +282,13 @@ function addEventListeners (mapper) {
       //  Focus on `Tab`
       if (!isMetaKey(event) && Keycode.isEventKey(event, 'tab')) {
         event.preventDefault()
-        selected = mapper.graph[0]
-        mapper.graph.focus(selected)
+        if (event.shiftKey) {
+          mapper.graph.undoFocus()
+        } else {
+          selected = mapper.graph[0]
+          mapper.graph.focus(selected)
+        }
+        console.log(mapper.graph.map(g => g.id))
         mapper.dirty = true
       }
 

--- a/lib/view.js
+++ b/lib/view.js
@@ -145,6 +145,8 @@ function clear (mapper) {
  * Private: Draws a node on the canvas
  */
 function draw_node (node, {context, offset}) {
+  // Set font size before calculating text widths
+  context.font = fontSize + 'px sans-serif'
 
   //  word wrap the text
   const text = wordWrap(node.text, context)
@@ -169,7 +171,6 @@ function draw_node (node, {context, offset}) {
 
   //  set text box styles
   context.fillStyle = 'rgba('+rgb+',0.8)'
-  context.font = fontSize + 'px sans-serif'
   context.textAlign = 'center'
 
   const lineHeight = fontSize * 1.25;

--- a/reasons.js
+++ b/reasons.js
@@ -1259,6 +1259,8 @@ function clear (mapper) {
  * Private: Draws a node on the canvas
  */
 function draw_node (node, {context, offset}) {
+  // Set font size before calculating text widths
+  context.font = fontSize + 'px sans-serif'
 
   //  word wrap the text
   const text = wordWrap(node.text, context)
@@ -1283,7 +1285,6 @@ function draw_node (node, {context, offset}) {
 
   //  set text box styles
   context.fillStyle = 'rgba('+rgb+',0.8)'
-  context.font = fontSize + 'px sans-serif'
   context.textAlign = 'center'
 
   const lineHeight = fontSize * 1.25;

--- a/reasons.js
+++ b/reasons.js
@@ -667,6 +667,7 @@ function addEventListeners (mapper) {
   let selected = null
   let dragging = null
   let clickPos = null
+  let clickOffset = null
   let metaKeyPressed = false
 
   const localPosition = (event) => {
@@ -776,19 +777,23 @@ function addEventListeners (mapper) {
   const dragStart = (event) => {
 
     const {position, collision} = detect(event)
+    if (dragging) { return }
 
     if (collision) {
       selected = collision
       mapper.graph.focus(selected)
       mapper.dirty = true
       clickPos = position
+      clickOffset = {
+        x: (selected.x1 + (selected.width / 2)) - position.x,
+        y: (selected.y1 + (selected.height /2)) - position.y
+      }
       dragging = selected
     }
 
     redraw(mapper)
   }
   mapper.DOM.addEventListener('mousedown', dragStart)
-  // mapper.DOM.addEventListener('touchstart', dragStart)
 
   //  Move a selected element on drag
   //  Highlight a hovered element
@@ -809,7 +814,12 @@ function addEventListeners (mapper) {
 
     //  Specify a node as the drag target when clicked
     if (dragging) {
-      dragging.move(localPosition(event))
+      const localPos = localPosition(event)
+      console.log('drag', localPos, clickOffset)
+      dragging.move({
+        x: localPos.x + clickOffset.x,
+        y: localPos.y + clickOffset.y
+      })
       mapper.dirty = true
     }
 

--- a/reasons.js
+++ b/reasons.js
@@ -232,13 +232,13 @@ function Graph(elements) {
   //  sort the elements so nodes are added before edges
   if (elements instanceof Array) {
     elements.sort((a,b) => {
-      return a.to ? 1: -1 
+      return a.to ? 1: -1
     }).forEach(el => this.add(el))
   }
 }
 
 
-/**  
+/**
  * Use Array as the prototype
  */
 Graph.prototype = Object.create(Array.prototype)
@@ -264,13 +264,13 @@ Graph.prototype.add = function (element) {
       return false
     }
 
-    //  Edges can connect independent or conjoined reasons. 
+    //  Edges can connect independent or conjoined reasons.
     //  If A B & C both already support D
     //  and a new edge is added from A to B or vice versa
     //  then the relationships should be merged [A,B] -> D
-    //  and C -> D kept unchanged      
+    //  and C -> D kept unchanged
     let commonChildren = Utils.intersection(
-      Utils.flatten(element.from.map(e => this.children(e))), 
+      Utils.flatten(element.from.map(e => this.children(e))),
       this.children(element.to)
     ).map(el => el.id)
 
@@ -292,7 +292,7 @@ Graph.prototype.add = function (element) {
         }
       })
     } else {
-      this.push(element)  
+      this.push(element)
     }
   }
 }
@@ -333,9 +333,9 @@ Graph.prototype.add = function (element) {
 
       //  also remove node from any complex relations
       edgesFrom.filter(e => e.from instanceof Array).map((e) => {
-        if (e.from.indexOf(el) > -1) 
+        if (e.from.indexOf(el) > -1)
           e.from.splice(e.from.indexOf(el), 1)
-        if (e.from.length === 1) 
+        if (e.from.length === 1)
           e.from = e.from[0]
       })
 
@@ -346,7 +346,7 @@ Graph.prototype.add = function (element) {
       })
     } else {
       this.splice(i, 1)
-    }  
+    }
   }
 
   //  permit chaining during tests
@@ -373,6 +373,18 @@ Graph.prototype.add = function (element) {
 
   //  permit chaining during tests
   return el
+}
+
+ Graph.prototype.undoFocus = function () {
+  const last = this.pop();
+  this.unshift(last);
+
+  this.forEach(function (e) {
+    e.focused = (e === last) ? true : false
+  })
+
+  //  permit chaining during tests
+  return last
 }
 
 
@@ -859,8 +871,13 @@ function addEventListeners (mapper) {
       //  Focus on `Tab`
       if (!isMetaKey(event) && Keycode.isEventKey(event, 'tab')) {
         event.preventDefault()
-        selected = mapper.graph[0]
-        mapper.graph.focus(selected)
+        if (event.shiftKey) {
+          mapper.graph.undoFocus()
+        } else {
+          selected = mapper.graph[0]
+          mapper.graph.focus(selected)
+        }
+        console.log(mapper.graph.map(g => g.id))
         mapper.dirty = true
       }
 


### PR DESCRIPTION
Previously all drags would jump the node to centre on the mouse.
Now, we remember the mouse offset, so we drag the node from the exact position we started at.
