### PR TITLE
Support interactions of multiple inline maps

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -19,52 +19,74 @@ module.exports = {
 }
 
 function setup(mapper) {
+  setupSharedStyles()
   const styleTag = Utils.buildNode('style')
   styleTag.innerHTML = `
     #${mapper.DOM.id} {
-      height: 100vh;
-    }
-    #reason-overlay {
-      font-size: 18px;
-      position:absolute;
-      top: 0; left: 0; right: 0;
-      height: 100vh;
-      background: rgba(0,0,0,0.75);
-    }
-    #edit-reason-input {
-      font-size: 18px;
-      padding: 1rem 1rem 0 1rem;
-      margin-top: 10vh;
-      box-sizing: border-box;
-    }
-    #reason-overlay__wrapper {
-      margin: auto;
-      margin-top: 40vh;
-      width:50%;
-      padding: 1rem;
-      flex-direction: column;
-      display: flex;
-    }
-    #reasons-overlay-toolbar {
-      margin: 0.75rem -0.5rem;
-    }
-    .reason-overlay__button {
-      font-size: inherit;
-      background-color: white;
-      padding: 0.5rem 1rem;
-      border: 1px solid grey;
-      border-radius: 4px;
-      margin: 0 0.5rem;
+      min-height: 100px;
     }
   `
   document.head.appendChild(styleTag)
   View.resize(mapper)
 }
 
+function setupSharedStyles() {
+  if (!document.head.querySelector('style[data-reasons-shared]')) {
+    const sharedStyles = Utils.buildNode('style', undefined, { 'data-reasons-shared': true })
+    sharedStyles.innerHTML = `
+      body.modal {
+        overflow-y: hidden;
+      }
+      #reason-overlay {
+        font-size: 18px;
+        position: fixed;
+        top: 0; left: 0; right: 0;
+        height: 100vh;
+        background: rgba(0,0,0,0.75);
+        touch-action: none;
+      }
+      #edit-reason-input {
+        font-size: 18px;
+        padding: 1rem 1rem 0 1rem;
+        margin-top: 10vh;
+        box-sizing: border-box;
+      }
+      #reason-overlay__wrapper {
+        margin: auto;
+        margin-top: 10vh;
+        width:50%;
+        padding: 1rem;
+        flex-direction: column;
+        display: flex;
+      }
+      #reasons-overlay-toolbar {
+        margin: 0.75rem -0.5rem;
+      }
+      .reason-overlay__button {
+        font-size: inherit;
+        background-color: white;
+        padding: 0.5rem 1rem;
+        border: 1px solid grey;
+        border-radius: 4px;
+        margin: 0 0.5rem;
+      }
+      [data-reasons-layout="inline"] {
+        touch-action: pinch-zoom;
+      }
+      .show-touch, .show-pointer {
+        display: none;
+      }
+    `
+    document.head.appendChild(sharedStyles)
+  }
+}
+
 function addEventListeners (mapper) {
 
   const hammer = new Hammer(mapper.DOM, {})
-  hammer.get('pan').set({ direction: Hammer.DIRECTION_ALL })
+  if (!mapper.inline) {
+    hammer.get('pan').set({ direction: Hammer.DIRECTION_ALL })
+  }
   hammer.get('pinch').set({ enable: true })
 
   // 3 finger swipes for undo/redo
@@ -81,11 +103,41 @@ function addEventListeners (mapper) {
   let clickOffset = null
   let metaKeyPressed = false
 
+  const elPosition = function( _el ) {
+    var target = _el,
+    target_width = target.offsetWidth,
+    target_height = target.offsetHeight,
+    target_left = target.offsetLeft,
+    target_top = target.offsetTop,
+    gleft = 0,
+    gtop = 0,
+    rect = {};
+
+    var moonwalk = function( _parent ) {
+    if (!!_parent) {
+        gleft += _parent.offsetLeft;
+        gtop += _parent.offsetTop;
+        moonwalk( _parent.offsetParent );
+    } else {
+        return rect = {
+        top: target.offsetTop + gtop,
+        left: target.offsetLeft + gleft,
+        bottom: (target.offsetTop + gtop) + target_height,
+        right: (target.offsetLeft + gleft) + target_width
+        };
+    }
+    };
+    moonwalk( target.offsetParent );
+    return rect;
+  }
+
   const localPosition = (event) => {
+    const pos = elPosition(event.target)
     const {x,y} = mapper.offset
+
     return {
-      x: (parseInt(event.x || event.pageX) / mapper.scale) - x,
-      y: (parseInt(event.y || event.pageY) / mapper.scale) - y
+      x: ((parseInt(event.offsetX)) / mapper.scale) - x,
+      y: ((parseInt(event.offsetY)) / mapper.scale) - y
     }
   }
 
@@ -93,9 +145,10 @@ function addEventListeners (mapper) {
    * Private: Returns mouse event and hovered element
    */
   function detect (event) {
+    const local = localPosition(event)
     return {
-      position: localPosition(event),
-      collision: mapper.graph.elements().find(el => el.collides(localPosition(event)))
+      position: local,
+      collision: mapper.graph.elements().find(el => el.collides(local))
     }
   }
 
@@ -120,6 +173,7 @@ function addEventListeners (mapper) {
   }
   hammer.on('doubletap', (hammerEvent) => {
     const event = hammerEvent.srcEvent
+    event.preventDefault()
     doubleClick(event)
   })
 
@@ -168,7 +222,7 @@ function addEventListeners (mapper) {
     }
   })
 
-  hammer.on('panmove', function (hammerEvent) {
+  const panMove = function (hammerEvent) {
     const event = hammerEvent.srcEvent
     const {collision} = detect(event)
     if (collision) { return dragMove(event) }
@@ -181,7 +235,8 @@ function addEventListeners (mapper) {
     mapper.dirty = true
     View.zero(mapper)
     redraw(mapper)
-  })
+  };
+  hammer.on('panmove', panMove)
 
   //  Draging an element selects and moves it
   //  Selecting nothing unfocuses the graph
@@ -268,7 +323,9 @@ function addEventListeners (mapper) {
 
   //  Close modal if click occurs outside text box
   window.addEventListener('click', (event) => {
-
+    // if (mapper.inline) {
+    //   event.preventDefault();
+    // }
     if (mapper.editMode && event.target.id === 'reason-overlay') {
       removeOverlay(mapper)
     }
@@ -348,10 +405,14 @@ function addEventListeners (mapper) {
   })
 
   const zoomAction = (event) => {
-    event.preventDefault()
-    if (event.target.id != mapper.DOM.id) {
+    if (event.target.id != mapper.DOM.firstElementChild.id) {
       return
     }
+    if (mapper.inline && !event.metaKey) {
+      metaWarning()
+      return;
+    }
+    event.preventDefault()
 
     mapper.dirty = true
     View.setScale(mapper, event.deltaY)
@@ -365,6 +426,9 @@ function addEventListeners (mapper) {
 
   hammer.on('pinch', (hammerEvent) => {
     if (mapper._isSwipping) { return }
+    if (mapper.inline) {
+      panMove(hammerEvent)
+    }
     hammerEvent.preventDefault()
     let tmpScale = hammerEvent.scale - _lastScale
 
@@ -386,6 +450,11 @@ let timeout
 function deleteElement(mapper, selected) {
   mapper.graph.remove(selected)
   mapper.dirty = true
+}
+
+function metaWarning() {
+  mapper.DOM.querySelector('')
+  console.log("Please hold CMD while scrolling to zoom");
 }
 
 function redraw(mapper) {
@@ -506,13 +575,14 @@ function addOverlay (mapper, element, highlightAll = false) {
   wrapper.appendChild(input)
   wrapper.appendChild(toolbarNode(mapper, element))
   document.body.appendChild(overlay)
+  document.body.classList.add('modal')
 
   //  Highlight text on element creation
   if (highlightAll) {
     input.select()
     input.setSelectionRange(0, input.value.length)
   }
-  wrapper.scrollIntoView()
+  input.scrollIntoView()
 }
 
 
@@ -539,6 +609,7 @@ function removeOverlay (argumentMap) {
   argumentMap.editMode = false
   argumentMap.altered = true
   document.querySelector('#reason-overlay').remove()
+  document.body.classList.remove('modal')
 }
 
 function isMetaKey (event) {

--- a/lib/view.js
+++ b/lib/view.js
@@ -42,6 +42,8 @@ module.exports = (function () {
     mapper.scale = 1
     mapper.offset = { x: 0, y: 0 }
 
+    mapper.inline = mapper.DOM.getAttribute('data-reasons-layout') == 'inline'
+
     let domBB = mapper.DOM.getBoundingClientRect()
     let canvas = Utils.buildNode(
       'canvas',

--- a/test/dual-maps.html
+++ b/test/dual-maps.html
@@ -7,9 +7,9 @@
       max-width: 700px;
       margin: 1rem auto;
     }
-    
+
     #a, #b {
-      /*height: 50vh;*/
+      height: 50vh;
       border: 1px solid #CCC;
     }
   </style>
@@ -20,13 +20,13 @@
 
   <p>He’s not a word hero. He’s a word hero because he was captured. I like text that wasn’t captured. Lorem Ispum is a choke artist. It chokes!</p>
 
-  <div id="a"></div>
+  <div id="a" data-reasons-layout="inline"></div>
 
   <p>I know words. I have the best words. I don't think anybody knows it was Russia that wrote Lorem Ipsum, but I don't know, maybe it was. It could be Russia, but it could also be China. It could also be lots of other people. It also could be some wordsmith sitting on their bed that weights 400 pounds. Ok? Some people have an ability to write placeholder text... It's an art you're basically born with. You either have it or you don't. You have so many different things placeholder text has to be able to do, and I don't believe Lorem Ipsum has the stamina.</p>
 
   <p>I will write some great placeholder text – and nobody writes better placeholder text than me, believe me – and I’ll write it very inexpensively. I will write some great, great text on your website’s Southern border, and I will make Google pay for that text. Mark my words. Despite the constant negative ipsum covfefe. Lorem Ipsum is FAKE TEXT! My text is long and beautiful, as, it has been well documented, are various other parts of my website. Look at these words. Are they small words? And he referred to my words - if they're small, something else must be small. I guarantee you there's no problem, I guarantee.</p>
 
-  <div id="b"></div>
+  <div id="b" data-reasons-layout="inline"></div>
 
 
   <p>Lorem Ipsum's father was with Lee Harvey Oswald prior to Oswald's being, you know, shot. Does everybody know that pig named Lorem Ipsum? She's a disgusting pig, right? My text is long and beautiful, as, it has been well documented, are various other parts of my website. I think the only difference between me and the other placeholder text is that I’m more honest and my words are more beautiful.</p>


### PR DESCRIPTION
This branch enables multiple maps to work on a single page.

By including an attribute on the map element `data-reasons-layout="inline"` this customises some behaviour, such as requiring  `CMD` to be held down to zoom the map with the mouse wheel, so that it doesn't interfere with scrolling the page.